### PR TITLE
Implement a 16 x 16 monochromatic grid

### DIFF
--- a/src/app/content.rs
+++ b/src/app/content.rs
@@ -109,12 +109,16 @@ impl SimpleComponent for ContentModel {
             Self::Input::Paint(x, y) => {
                 let column = (x / CELL_SIZE) as usize;
                 let line = (y / CELL_SIZE) as usize;
-                self.grid[line][column] = 1;
+                if is_in_bounds(line, column, &self.grid) {
+                    self.grid[line][column] = 1;
+                }
             }
             Self::Input::Erase(x, y) => {
                 let column = (x / CELL_SIZE) as usize;
                 let line = (y / CELL_SIZE) as usize;
-                self.grid[line][column] = 0;
+                if is_in_bounds(line, column, &self.grid) {
+                    self.grid[line][column] = 0;
+                }
             }
         }
 
@@ -164,4 +168,8 @@ fn redraw(cx: &gtk::cairo::Context, grid: &[[u8; 16]; 16]) {
     }
     cx.stroke()
         .expect("Should be able to stroke line");
+}
+
+fn is_in_bounds(i: usize, j: usize, grid: &[[u8; 16]]) -> bool {
+    i < grid.len() && j < grid[0].len()
 }

--- a/src/app/content.rs
+++ b/src/app/content.rs
@@ -68,6 +68,16 @@ impl SimpleComponent for ContentModel {
                     },
                 },
 
+                add_controller = gtk::GestureDrag {
+                    set_button: gtk::gdk::BUTTON_SECONDARY,
+
+                    connect_drag_update[sender] => move |gesture, dx, dy| {
+                        let (x, y) = gesture.start_point()
+                            .expect("If it started, then it has a starting point");
+                        sender.input(Self::Input::Erase(x + dx, y + dy));
+                    },
+                },
+
                 connect_resize[sender] => move |_, _, _| {
                     sender.input(Self::Input::DrawEmptyGrid);
                 },

--- a/src/app/content.rs
+++ b/src/app/content.rs
@@ -108,4 +108,24 @@ fn redraw(cx: &gtk::cairo::Context, grid: &[[u8; 16]; 16]) {
                 .expect("Should be able to fill cell");
         }
     }
+
+    // Draw the grid
+    cx.set_source_rgba(0.5, 0.5, 0.5, 0.5);  // Gray
+    cx.set_line_width(1.0);
+    // To draw a 1-pixel wide line, you have to aim to the "center" of the pixel
+    // Otherwise, it gets blurred
+    for line in 0..grid.len() {
+        // Horizontal lines
+        let y = (line as f64) * CELL_SIZE;
+        cx.move_to(0.0, y - 0.5);  // Discount half a pixel
+        cx.line_to(256.0, y - 0.5);  // Discount half a pixel
+    }
+    for column in 0..grid[0].len() {
+        // Vertical lines
+        let x = (column as f64) * CELL_SIZE;
+        cx.move_to(x - 0.5, 0.0);  // Discount half a pixel
+        cx.line_to(x - 0.5, 256.0);  // Discount half a pixel
+    }
+    cx.stroke()
+        .expect("Should be able to stroke line");
 }

--- a/src/app/content.rs
+++ b/src/app/content.rs
@@ -58,6 +58,16 @@ impl SimpleComponent for ContentModel {
                     },
                 },
 
+                add_controller = gtk::GestureDrag {
+                    set_button: gtk::gdk::BUTTON_PRIMARY,
+
+                    connect_drag_update[sender] => move |gesture, dx, dy| {
+                        let (x, y) = gesture.start_point()
+                            .expect("If it started, then it has a starting point");
+                        sender.input(Self::Input::Paint(x + dx, y + dy));
+                    },
+                },
+
                 connect_resize[sender] => move |_, _, _| {
                     sender.input(Self::Input::DrawEmptyGrid);
                 },

--- a/src/app/content.rs
+++ b/src/app/content.rs
@@ -166,6 +166,14 @@ fn redraw(cx: &gtk::cairo::Context, grid: &[[u8; 16]; 16]) {
         cx.move_to(x - 0.5, 0.0);  // Discount half a pixel
         cx.line_to(x - 0.5, 256.0);  // Discount half a pixel
     }
+
+    // Draw the border
+    cx.move_to(0.0, 0.0);
+    cx.line_to(256.0, 0.0);
+    cx.line_to(256.0, 256.0);
+    cx.line_to(0.0, 256.0);
+    cx.line_to(0.0, 0.0);
+
     cx.stroke()
         .expect("Should be able to stroke line");
 }

--- a/src/app/content.rs
+++ b/src/app/content.rs
@@ -14,6 +14,7 @@ pub(crate) struct ContentInit;
 pub(crate) enum ContentInput {
     DrawEmptyGrid,
     Paint(f64, f64),
+    Erase(f64, f64),
 }
 
 #[derive(Debug)]
@@ -42,8 +43,18 @@ impl SimpleComponent for ContentModel {
                 set_content_height: 256,
 
                 add_controller = gtk::GestureClick {
+                    set_button: gtk::gdk::BUTTON_PRIMARY,
+
                     connect_pressed[sender] => move |_, _, x, y| {
                         sender.input(Self::Input::Paint(x, y));
+                    },
+                },
+
+                add_controller = gtk::GestureClick {
+                    set_button: gtk::gdk::BUTTON_SECONDARY,
+
+                    connect_pressed[sender] => move |_, _, x, y| {
+                        sender.input(Self::Input::Erase(x, y));
                     },
                 },
 
@@ -79,6 +90,11 @@ impl SimpleComponent for ContentModel {
                 let column = (x / CELL_SIZE) as usize;
                 let line = (y / CELL_SIZE) as usize;
                 self.grid[line][column] = 1;
+            }
+            Self::Input::Erase(x, y) => {
+                let column = (x / CELL_SIZE) as usize;
+                let line = (y / CELL_SIZE) as usize;
+                self.grid[line][column] = 0;
             }
         }
 


### PR DESCRIPTION
Here's a 16 x 16 grid.

Use the primary mouse button to draw, and the secondary one to erase.

[Gravação de tela de 2023-12-18 23-49-19.webm](https://github.com/tiago-vargas/pixel-art-app/assets/78927143/ac037839-9e5a-4e76-b0de-12f686afc3aa)

Note that you can click and drag to either draw or erase.
No need to be clicking every single cell.